### PR TITLE
Fix README how to disable org-pomodoro-third-time-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -27,11 +27,11 @@ To install it manually:
 
 1. Clone this directory to somewhere on ~load-path~.
 2. ~(require 'org-pomodoro-third-time)~
-3. Run ~(org-pomodoro-third-time-mode +1)~ to enable (can also be put in =init.el=),
+3. Run ~(org-pomodoro-third-time-mode)~ to enable (can also be put in =init.el=),
    or ~M-x org-pomodoro-third-time-mode~ to toggle.
 
 If you would like to disable this mode, run ~(org-pomodoro-third-time-mode
-nil)~.
+-1)~.
 
 * Usage
 :PROPERTIES:


### PR DESCRIPTION
To enable a mode from non-interactive emacs lisp, it's sufficient to just run `(org-pomodoro-third-time-mode)`. An explicit `+1` is not necessary, just optional [1]. This also means that `(org-pomodoro-third-time-mode nil)` will _enable_ the mode instead of disabling it as stated in the readme, as a `nil` argument is the same as not providing an argument. Instead, to disable a mode, one most provide  a negative argument
``` elisp
(org-pomodoro-third-time-mode -1)
```

See the [elisp manual](https://www.gnu.org/software/emacs/manual/html_node/elisp/Defining-Minor-Modes.html):
> If called interactively with no argument it toggles the mode on or off. A positive prefix argument enables the mode, any other prefix argument disables it.

[1]: To be honest I'm not sure if this is true for all past emacs versions and user-defined minor-mode functions, but this is the default behaviour from `define-minor-mode`.